### PR TITLE
config.active_support.isolation_level = :fiber

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module Example
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Configures the locality of most of Rails internal state. If you use a
+    # fiber based server or job processor (e.g. `falcon`), you should set it to
+    # `:fiber`. Otherwise it is best to use `:thread` locality. Defaults to `:thread`.
+    config.active_support.isolation_level = :fiber
   end
 end


### PR DESCRIPTION
Bring back setting Rails' `isolation_level` which was removed in https://github.com/socketry/falcon-rails-example/commit/ed198861d48dd43170015a7ccde605f048a1c198#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9L28 (not sure why) adding language from https://github.com/rails/rails/blob/main/guides/source/configuring.md#configactive_supportisolation_level

## Types of Changes

- Maintenance.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
